### PR TITLE
Fix the no-close window bug

### DIFF
--- a/chrome/content/alert/alert.js
+++ b/chrome/content/alert/alert.js
@@ -19,6 +19,7 @@ var gmanager_Alert = new function() {
   this.OPEN_TIME = 2000;
 
   this._isPlaying = true;
+  this.internalHeightCounter = 0;
 
   this.load = function() {
     // Load the services
@@ -121,6 +122,7 @@ var gmanager_Alert = new function() {
           window.moveBy(0, -this.SLIDE_INCREMENT);
           window.resizeBy(0, this.SLIDE_INCREMENT);
         } else {
+          this.internalHeightCounter = this.FINAL_HEIGHT;
           this._startTimer(this.SLIDE_STAGE, this.OPEN_TIME);
         }
 
@@ -140,9 +142,11 @@ var gmanager_Alert = new function() {
       }
       case this.CLOSE_STAGE:
       {
-        if (window.outerHeight > 1) {
+        if (this.internalHeightCounter > 1) {
           window.moveBy(0, this.SLIDE_INCREMENT);
           window.resizeBy(0, -this.SLIDE_INCREMENT);
+
+          this.internalHeightCounter -= this.SLIDE_INCREMENT;
         } else {
           this.close();
         }
@@ -152,6 +156,7 @@ var gmanager_Alert = new function() {
       default:
       {
         gmanager_Utils.log("Unknown stage...definitely should not be here!");
+        this.close();
         break;
       }
     }


### PR DESCRIPTION
The behaviour observed is that the notification window stops moving at some point, so using "window.outerHeight" to time when it should close can leave the window hang, which causes a number of bugs within Firefox (mainly around drag and drop features).

Figuring out why the window stops moving is a bigger deal, but you should never rely on outward things to see if we should close.  Always close when a timer should finish.
