### PR TITLE
Use more correct "null" for JSON parse

### DIFF
--- a/components/gmServiceGmail.js
+++ b/components/gmServiceGmail.js
@@ -546,7 +546,7 @@ gmServiceGmail.prototype = {
             var loc1 = data.indexOf("var VIEW_DATA=[[");
             var loc2 = data.lastIndexOf("var GM_TIMING_END_CHUNK2");
             var viewData = data.substring(loc1 + 14, loc2 - 2);
-            viewData = viewData.replace(/,(?=,)/g, ',""').replace(/,(?=[],])/g, ',""').replace(/\[(?=,)/g, '[""');
+            viewData = viewData.replace(/,(?=,)/g, ',null').replace(/,(?=[],])/g, ',null').replace(/\[(?=,)/g, '[null');
             var msgs = JSON.parse(viewData);
             // Initialize the snippets
             this._snippets = [];


### PR DESCRIPTION
Rather than "" for replacing `[,`, `,,` and `,]`.

You can force the issue (maybe #26) by sending yourself an email with ,,, in the title (I had one from my mam... `Fwd: Fw: ,,,,not in your house,obviously !!!!`.  With the current code, that would come through as something like,

`[1, 22, "Fwd: Fw: ,,,,not in your house,obviously !!!!", "asdf"]`

and after processing end up as

`[1, 22, "Fwd: Fw: ,"","","",not in your house,obviously !!!!", "asdf"]`

which cannot be parsed into correct JSON objects.

With this change, it'll be processed to 

`[1, 22, "Fwd: Fw: ,null,null,null,not in your house,obviously !!!!", "asdf"]`

Definitely not a _perfect_ solution, and can look into a better way, but at least this doesn't break your entire inbox.  Overall, I think CSV processing would be better for these bits, instead of JSON processing, but that's more long term.
